### PR TITLE
Fix Group My Tabs button behaviour

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,42 +1,128 @@
 function getDomainFromURL(url) {
   try {
-    return new URL(url).hostname;
+    return new URL(url).hostname.replace(/^www\./, '');
   } catch (e) {
     return null;
   }
 }
 
-chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
-  chrome.tabs.query({}, (tabs) => {
-    let tabsGroupedByURL = {};
-    for (let tab of tabs) {
-      let domain = getDomainFromURL(tab.url);
-      if (domain) {
-        if (!tabsGroupedByURL[domain]) {
-          tabsGroupedByURL[domain] = [];
-        }
-        tabsGroupedByURL[domain].push(tab.id);
-      }
-    }
+function getGroupForTab(groups, tab) {
+  return groups.filter(group => group.tabIds.includes(tab.id))[0];
+}
 
-    for (let url in tabsGroupedByURL) {
-      if (tabsGroupedByURL[url].length > 1) {
-        chrome.tabs.group(
-          {
-            tabIds: tabsGroupedByURL[url],
-          },
-          (groupId) => {
-            if (chrome.runtime.lastError) {
-              console.error(
-                "Error creating group:",
-                chrome.runtime.lastError.message
-              );
-            }
-          }
-        );
+chrome.runtime.onMessage.addListener(async (message, sender, sendResponse) => {
+  const existingGroupsAndTabs = [];
+
+  // Wrap the chrome API calls in Promises
+  const queryGroups = () => {
+    return new Promise((resolve) => {
+      chrome.tabGroups.query({}, (groups) => {
+        resolve(groups);
+      });
+    });
+  };
+
+  const queryTabs = (groupId) => {
+    return new Promise((resolve) => {
+      chrome.tabs.query({ groupId }, (tabs) => {
+        resolve(tabs);
+      });
+    });
+  };
+
+  const queryAllTabs = () => {
+    return new Promise((resolve) => {
+      chrome.tabs.query({}, (tabs) => {
+        resolve(tabs);
+      });
+    });
+  };
+
+  // Wait for the groups to be fetched
+  const groups = await queryGroups();
+
+  for(let i = 0; i < groups.length; i++) {
+    const group = groups[i];
+
+    existingGroupsAndTabs.push({
+      title: group.title,
+      color: group.color,
+      collapsed: group.collapsed,
+      id: group.id,
+      windowId: group.windowId,
+      tabIds: []
+    });
+
+    // Wait for the tabs to be fetched for this group
+    const tabs = await queryTabs(group.id);
+
+    tabs.forEach(tab => existingGroupsAndTabs[i].tabIds.push(tab.id));
+  }
+
+  // Wait for all tabs to be fetched
+  const allTabs = await queryAllTabs();
+  const tabsGroupedByUrl = {};
+
+  for(const tab of allTabs) {
+    let domain = getDomainFromURL(tab.url);
+    const existingGroup = getGroupForTab(existingGroupsAndTabs, tab);
+
+    if(domain) {
+      if(!tabsGroupedByUrl.hasOwnProperty(domain)) {
+        const [firstLetter, ...rest] = domain.split('.')[0]
+        tabsGroupedByUrl[domain] = {domain, ids: [], title: firstLetter.toUpperCase() + rest.join(''), color: null, groupId: null, collapsed: true};
+      }
+      tabsGroupedByUrl[domain].ids.push(tab.id);
+
+      if(tabsGroupedByUrl[domain].groupId === null && existingGroup) {
+        tabsGroupedByUrl[domain].groupId = existingGroup.id;
+
+        if(existingGroup.color) tabsGroupedByUrl[domain].color = existingGroup.color;
+        else delete tabsGroupedByUrl[domain].color
+
+        if(existingGroup.title) tabsGroupedByUrl[domain].title = existingGroup.title;
+        if('collapsed' in existingGroup) tabsGroupedByUrl[domain].collapsed = existingGroup.collapsed;
       }
     }
-  });
+  }
+
+  for(const url in tabsGroupedByUrl) {
+    if(tabsGroupedByUrl[url].ids.length > 1) {
+      const opts = {
+        tabIds: tabsGroupedByUrl[url].ids
+      };
+      if(tabsGroupedByUrl[url].groupId) opts.groupId = tabsGroupedByUrl[url].groupId;
+
+      chrome.tabs.group(
+        opts,
+        (groupId) => {
+          if (chrome.runtime.lastError) {
+            console.error(
+              "Error creating group:",
+              chrome.runtime.lastError.message
+            );
+          }
+
+          if(!opts.groupId) {
+            chrome.tabGroups.update(groupId, { title: tabsGroupedByUrl[url].title }, () => {
+              if (chrome.runtime.lastError) {
+                console.error(
+                  "Error updating new group title:",
+                  chrome.runtime.lastError.message
+                );
+              }
+            });
+
+            const groupPosition = existingGroupsAndTabs.reduce((acc, obj) => {
+              return acc + (obj.tabIds ? obj.tabIds.length : 0);
+            }, 0);
+
+            chrome.tabGroups.move(groupId, { index: groupPosition });
+          }
+        }
+      );
+    }
+  }
 
   sendResponse({ status: "done" });
 });

--- a/manifest.json
+++ b/manifest.json
@@ -4,7 +4,8 @@
     "version": "1.0",
     "description": "Group tabs by domain in Chrome with one click, enhancing built-in functionality for organized browsing.",
     "permissions": [
-        "tabs"
+        "tabs",
+        "tabGroups"
         ],
     "background": {
         "service_worker": "background.js"


### PR DESCRIPTION
In this PR, I am modifying the behaviour that occurs when a user hits the Group My Tabs button.

1. It now does not create new groups for each group of tabs, rather groups them up into existing groups, if there are any. This preserves the title and colour of the existing groups. This is a bug in the current version of the extension.
2. For a new group of tabs, use the hostname of the tabs for the title of the new group.

https://github.com/AdamKmet1997/Group-My-Tabs/assets/6564666/8ce47f59-e290-4433-ac9d-f267b707bbf3


